### PR TITLE
Add password reset designs

### DIFF
--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -1,17 +1,3 @@
-* {
-  box-sizing: border-box;
-}
-
-body {
-  background-attachment: fixed;
-  background-image: url("../images/background.jpeg");
-  background-repeat: no-repeat;
-  background-size: 100% 100%;
-  color: #0a0966;
-  font-family: Arial, Helvetica, sans-serif;
-  margin: 0;
-}
-
 .fixed {
   overflow: hidden;
 }
@@ -56,34 +42,6 @@ body {
 
 .signup-form {
   padding: 10px 20%;
-}
-
-input {
-  border: 1px solid lightgray;
-  border-radius: 6px;
-  color: #0a0966;
-  display: block;
-  font-size: 0.9em;
-  padding: 10px;
-  transition: border 1s;
-  width: 100%;
-}
-
-input:hover {
-  border: 1px solid #0a0966;
-}
-
-input[type="submit"] {
-  background-color: #040559;
-  border: none;
-  border-radius: 20px;
-  color: white;
-  cursor: pointer;
-  transition: background-color 1s;
-}
-
-input[type="submit"]:hover {
-  background-color: #000ddd;
 }
 
 .footer-text {

--- a/ui/css/login-form.css
+++ b/ui/css/login-form.css
@@ -87,3 +87,29 @@
     width: 50%;
   }
 }
+
+.password-reset-dialog {
+  position: fixed;
+  text-align: center;
+  top: 0;
+  transition: top 0.5s linear;
+  visibility: hidden;
+  width: 100%;
+}
+
+.password-reset-message {
+  background-color: #9ea10a;
+  border-radius: 5px;
+  opacity: 0;
+  padding: 8px;
+  transition: opacity 0.5s linear;
+}
+
+.show-reset-dialog {
+  top: 4%;
+  visibility: visible;
+}
+
+.show-reset-message {
+  opacity: 1;
+}

--- a/ui/css/password-reset.css
+++ b/ui/css/password-reset.css
@@ -1,0 +1,23 @@
+form {
+  background: rgb(240, 240, 240); /* Fallback background. */
+  background: rgba(240, 240, 240, 0.9);
+  border-radius: 6px;
+  margin: auto;
+  margin-top: 5%;
+  padding: 10px;
+  width: 30%;
+}
+
+/* Adjust form width for smartphone screen sizes. */
+@media only screen and (max-width: 600px) {
+  form {
+    width: 90%;
+  }
+}
+
+/* Adjust form width for tablet screen sizes. */
+@media only screen and (min-width: 600px) and (max-width: 800px) {
+  form {
+    width: 50%;
+  }
+}

--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -1,0 +1,41 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  background-attachment: fixed;
+  background-image: url("../images/background.jpeg");
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  color: #0a0966;
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+}
+
+input {
+  border: 1px solid lightgray;
+  border-radius: 6px;
+  color: #0a0966;
+  display: block;
+  font-size: 0.9em;
+  padding: 10px;
+  transition: border 1s;
+  width: 100%;
+}
+
+input:hover {
+  border: 1px solid #0a0966;
+}
+
+input[type="submit"] {
+  background-color: #040559;
+  border: none;
+  border-radius: 20px;
+  color: white;
+  cursor: pointer;
+  transition: background-color 1s;
+}
+
+input[type="submit"]:hover {
+  background-color: #000ddd;
+}

--- a/ui/html/password-reset.html
+++ b/ui/html/password-reset.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link rel="stylesheet" href="../css/styles.css" />
+    <link rel="stylesheet" href="../css/password-reset.css" />
+    <title>Document</title>
+  </head>
+  <body>
+    <form action="#">
+      <input type="password" placeholder="Enter new password *" /><br />
+      <input type="password" placeholder="Confirm new password *" /><br />
+      <input type="submit" value="Reset Password..." />
+    </form>
+  </body>
+</html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -10,6 +10,7 @@
       integrity="sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ"
       crossorigin="anonymous"
     />
+    <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/index.css" />
     <link rel="stylesheet" href="css/login-form.css" />
     <title>Kabedo</title>
@@ -80,9 +81,20 @@
           /><br />
           <input type="submit" value="Login" />
         </form>
-        <p class="footer-text">Forgot Password? <button>Reset...</button></p>
+        <p class="footer-text">
+          Forgot Password? <button id="reset-password">Reset...</button>
+        </p>
       </div>
     </div>
+
+    <!-- Password Reset Dialog. -->
+    <div class="password-reset-dialog">
+      <span class="password-reset-message">
+        Check your email for a password reset link...
+      </span>
+    </div>
+
+    <script src="js/password-reset.js"></script>
     <script src="js/login-form.js"></script>
   </body>
 </html>

--- a/ui/js/password-reset.js
+++ b/ui/js/password-reset.js
@@ -1,0 +1,18 @@
+var passwordResetButton = document.getElementById("reset-password");
+passwordResetButton.addEventListener("click", notifyUser);
+
+function notifyUser() {
+  var message = document.querySelector(".password-reset-message");
+  var dialog = document.querySelector(".password-reset-dialog");
+  toggleClasses(message, dialog);
+  passwordResetButton.disabled = true;
+  setTimeout(() => {
+    toggleClasses(message, dialog);
+    passwordResetButton.disabled = false;
+  }, 3500);
+}
+
+function toggleClasses(message, dialog) {
+  message.classList.toggle("show-reset-message");
+  dialog.classList.toggle("show-reset-dialog");
+}


### PR DESCRIPTION
### Goal to Achieve
Add designs for the feature to enable users to reset their passwords
#### Changes to Make
- Show popup message when a user clicks the password reset button
- Add password reset HTML page
- Refactor common CSS code to `styles.css`
#### Manual Testing
- Check out this branch (`password-reset-164847569`) and open the `ui/index.html` file
- Click the login button (bottom right), then click the reset button in the login form that pops up.
- Verify that a popup message is displayed
- To view the password reset form design, open the 'ui/html/password-reset.html' file
#### Screenshots
**Notification Message**
![image](https://user-images.githubusercontent.com/34346070/60803247-73607600-a183-11e9-9561-27f33faa6dfd.png)

**Password Reset Form**
![image](https://user-images.githubusercontent.com/34346070/60803195-5a57c500-a183-11e9-934f-6f24946426c8.png)

#### Relevant PT Stories
[#164847569](https://www.pivotaltracker.com/story/show/164847569)