### PR TITLE
Make navigation bar sticky as a page is scrolled

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -56,6 +56,9 @@ html {
   flex-direction: row;
   justify-content: space-between;
   padding: 5px;
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
 }
 
 .left-content {

--- a/ui/js/homepage.js
+++ b/ui/js/homepage.js
@@ -1,5 +1,6 @@
 toggleReactions();
 toggleCommentReactions();
+handleNavigation();
 
 var icon;
 var oppositeIcon;
@@ -92,4 +93,11 @@ function isDisliked(dislikeIcon) {
   } else {
     return false;
   }
+}
+
+function handleNavigation() {
+  var profileLink = document.querySelector(".view-profile");
+  profileLink.addEventListener("click", function() {
+    window.location.href = "user-profile.html";
+  });
 }


### PR DESCRIPTION
## Goal to Achieve
Improve user navigation experience
### Changes to Make
- Set navigation bar's CSS `top` property to zero
- Redirect to user profile page when respective link is clicked
### Manual Testing
- Open `ui/html/homepage.html` and scroll down the page. The navigation bar should remain at the top of the page.
- Click the `View Profile` link on the navigation bar. You should be redirected to the user profile page
### Relevant PT Stories
[#167901646](https://www.pivotaltracker.com/story/show/167901646)